### PR TITLE
perf: avoid to collect metrics if it has disabled

### DIFF
--- a/src/collectors/mnesia/prometheus_mnesia_collector.erl
+++ b/src/collectors/mnesia/prometheus_mnesia_collector.erl
@@ -101,10 +101,15 @@ deregister_cleanup(_) -> ok.
 -spec collect_mf(_Registry, Callback) -> ok when
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:callback().
-collect_mf(_Registry, Callback) ->
+collect_mf(Registry, Callback) ->
+  EnabledMetrics = enabled_metrics(),
+  do_collect_mf(EnabledMetrics, Registry, Callback).
+
+do_collect_mf([], _Registry, _Callback) ->
+  ok;
+do_collect_mf(EnabledMetrics, _Registry, Callback) ->
   case mnesia_running() of
     true ->
-      EnabledMetrics = enabled_metrics(),
       Metrics = metrics(EnabledMetrics),
       [add_metric_family(Metric, Callback)
        || {Name, _, _, _}=Metric <- Metrics, metric_enabled(Name, EnabledMetrics)];

--- a/src/collectors/vm/prometheus_vm_dist_collector.erl
+++ b/src/collectors/vm/prometheus_vm_dist_collector.erl
@@ -267,9 +267,14 @@ deregister_cleanup(_) -> ok.
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:callback().
 %% @private
-collect_mf(_Registry, Callback) ->
-  Metrics = metrics(),
+collect_mf(Registry, Callback) ->
   EnabledMetrics = enabled_metrics(),
+  do_collect_mf(EnabledMetrics, Registry, Callback).
+
+do_collect_mf([], _Registry, _Callback) ->
+  ok;
+do_collect_mf(EnabledMetrics, _Registry, Callback) ->
+  Metrics = metrics(),
   [add_metric_family(Metric, Callback)
    || {Name, _, _, _}=Metric <- Metrics, metric_enabled(Name, EnabledMetrics)],
   ok.

--- a/src/collectors/vm/prometheus_vm_memory_collector.erl
+++ b/src/collectors/vm/prometheus_vm_memory_collector.erl
@@ -103,9 +103,14 @@ deregister_cleanup(_) -> ok.
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:callback().
 %% @private
-collect_mf(_Registry, Callback) ->
-  Metrics = metrics(),
+collect_mf(Registry, Callback) ->
   EnabledMetrics = enabled_metrics(),
+  do_collect_mf(EnabledMetrics, Registry, Callback).
+
+do_collect_mf([], _Registry, _Callback) ->
+  ok;
+do_collect_mf(EnabledMetrics, _Registry, Callback) ->
+  Metrics = metrics(),
   [add_metric_family(Metric, Callback)
    || {Name, _, _, _}=Metric <- Metrics, metric_enabled(Name, EnabledMetrics)],
   ok.

--- a/src/collectors/vm/prometheus_vm_msacc_collector.erl
+++ b/src/collectors/vm/prometheus_vm_msacc_collector.erl
@@ -188,9 +188,14 @@ deregister_cleanup(_) -> ok.
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:callback().
 %% @private
-collect_mf(_Registry, Callback) ->
-  Metrics = metrics(),
+collect_mf(Registry, Callback) ->
   EnabledMetrics = enabled_metrics(),
+  do_collect_mf(EnabledMetrics, Registry, Callback).
+
+do_collect_mf([], _Registry, _Callback) ->
+  ok;
+do_collect_mf(EnabledMetrics, _Registry, Callback) ->
+  Metrics = metrics(),
   [add_metric_family(Metric, Callback)
    || {Name, _, _, _}=Metric <- Metrics, metric_enabled(Name, EnabledMetrics)],
   ok.

--- a/src/collectors/vm/prometheus_vm_statistics_collector.erl
+++ b/src/collectors/vm/prometheus_vm_statistics_collector.erl
@@ -140,9 +140,14 @@ deregister_cleanup(_) -> ok.
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:callback().
 %% @private
-collect_mf(_Registry, Callback) ->
-  Metrics = metrics(),
+collect_mf(Registry, Callback) ->
   EnabledMetrics = enabled_metrics(),
+  do_collect_mf(EnabledMetrics, Registry, Callback).
+
+do_collect_mf([], _Registry, _Callback) ->
+  ok;
+do_collect_mf(EnabledMetrics, _Registry, Callback) ->
+  Metrics = metrics(),
   [add_metric_family(Metric, Callback)
    || {Name, _, _, _}=Metric <- Metrics, metric_enabled(Name, EnabledMetrics)],
   ok.

--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -214,9 +214,14 @@ deregister_cleanup(_) -> ok.
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:callback().
 %% @private
-collect_mf(_Registry, Callback) ->
-  Metrics = metrics(),
+collect_mf(Registry, Callback) ->
   EnabledMetrics = enabled_metrics(),
+  do_collect_mf(EnabledMetrics, Registry, Callback).
+
+do_collect_mf([], _Registry, _Callback) ->
+  ok;
+do_collect_mf(EnabledMetrics, _Registry, Callback) ->
+  Metrics = metrics(),
   [add_metric_family(Metric, Callback)
    || {Name, _, _}=Metric <- Metrics, metric_enabled(Name, EnabledMetrics)],
   ok.


### PR DESCRIPTION
The `prometheus_vm_dist_collector` traverses all ports every time it collects information, but in a huge TCP connection testing scenario, a single Erlang node may have around 6 million ports. This causes the prometheus_vm_dist_collector to take too much time for data collection.

Even if the collector is disabled, it will still collect data first and filter out unnecessary metrics.

In this fix, just skip to collect the metrics if it has been disabled